### PR TITLE
Change the name of the Administrators group

### DIFF
--- a/agent/winusers.ps1
+++ b/agent/winusers.ps1
@@ -1,6 +1,6 @@
 function Get-AdminUser {
 	param([string] $username)
-	$admingroup = Get-LocalGroupMember -Group "Administrateurs"
+	$admingroup = Get-LocalGroupMember -Group "Administrators"
 	$userType = "Local user"
 	
 	foreach ($admin in $admingroup) {


### PR DESCRIPTION
Could we discuss why this is implemented the way that it is currently and potentially figure out a way to handle this for different language systems?