### PR TITLE
Reference Administrators group by SID to avoid localization issues.

### DIFF
--- a/agent/winusers.ps1
+++ b/agent/winusers.ps1
@@ -1,6 +1,6 @@
 function Get-AdminUser {
 	param([string] $username)
-	$admingroup = Get-LocalGroupMember -Group "Administrateurs"
+	$admingroup = Get-LocalGroupMember -SID "S-1-5-32-544"
 	$userType = "Local user"
 	
 	foreach ($admin in $admingroup) {


### PR DESCRIPTION
Suggested by @CraigFox in #19.
https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows